### PR TITLE
style: HeaderとHamburgerMenuのUIを修正した

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-gray-900 text-white w-full`}
       >
         <Header />
-        <main className="relative w-full h-[calc(100vh-40px)] md:h-[calc(100vh-48px)] lg:h-[calc(100vh-56px)] overflow-x-hidden">
+        <main className="w-full h-[calc(100vh-40px)] md:h-[calc(100vh-48px)] lg:h-[calc(100vh-56px)] overflow-x-hidden">
           {children}
           <HamburgerModal />
         </main>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -10,7 +10,7 @@ import { NavLinks } from "@/components/navigation/link";
  */
 export default function Header(): JSX.Element {
   return (
-    <header className="w-full h-10 md:h-12 lg:h-14 bg-gray-950 border-b border-gray-800 flex items-center">
+    <header className="w-full h-16 md:h-18 lg:h-20 bg-gray-950 border-b border-gray-800 flex items-center">
       <div className="container mx-auto flex items-center justify-between px-2">
         <HeaderLogo />
         <NavLinks />

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -11,7 +11,7 @@ import { NavLinks } from "@/components/navigation/link";
 export default function Header(): JSX.Element {
   return (
     <header className="w-full h-16 md:h-18 lg:h-20 bg-gray-950 border-b border-gray-800 flex items-center">
-      <div className="container mx-auto flex items-center justify-between px-2">
+      <div className="w-full flex items-center justify-between px-4">
         <HeaderLogo />
         <NavLinks />
         <HamburgerMenu />

--- a/src/components/layout/header/HeaderLogo.tsx
+++ b/src/components/layout/header/HeaderLogo.tsx
@@ -16,7 +16,7 @@ export default function HeaderLogo(): JSX.Element {
   return (
     <div onClick={handleCloseHamburger}>
       <Link href="/" className="hover:opacity-60 transition-opacity duration-200">
-        <Text className="font-bold text-base md:text-lg lg:text-xl">My Portfolio</Text>
+        <Text className="font-bold text-xl md:text-2xl lg:text-3xl">My Portfolio</Text>
       </Link>
     </div>
   );

--- a/src/components/navigation/hamburger/HamburgerMenu.tsx
+++ b/src/components/navigation/hamburger/HamburgerMenu.tsx
@@ -5,6 +5,7 @@ import { HiMenu, HiX } from "react-icons/hi";
 import { useAtomValue } from "jotai";
 import { hamburgerActionAtom } from "@/store/hamburger/hamburgerActionAtom";
 import { useHamburger } from "@/hooks/navigation";
+import { Button } from "@/components/ui";
 
 /**
  * @description ハンバーガーメニューコンポーネント
@@ -17,13 +18,9 @@ export default function HamburgerMenu(): JSX.Element {
 
   return (
     <>
-      <button
-        className="md:hidden text-2xl focus:outline-none"
-        onClick={handleToggleHamburger}
-        aria-label="Toggle menu"
-      >
-        {isOpen ? <HiX /> : <HiMenu />}
-      </button>
+      <Button className="md:hidden py-3 md:py-5 lg:py-6" onClick={handleToggleHamburger}>
+        {isOpen ? <HiX className="text-xl" /> : <HiMenu className="text-xl" />}
+      </Button>
     </>
   );
 }

--- a/src/components/navigation/hamburger/HamburgerModal.tsx
+++ b/src/components/navigation/hamburger/HamburgerModal.tsx
@@ -22,7 +22,7 @@ export default function HamburgerModal(): JSX.Element {
     <>
       <nav
         className={cn(
-          "md:hidden bg-slate-800 fixed top-[64px] bottom-0 w-48 sm:w-64 h-full right-0 transition-all ease-in-out",
+          "md:hidden bg-slate-800 fixed top-16 bottom-0 w-48 sm:w-64 h-full right-0 transition-all ease-in-out",
           {
             "right-0": isOpen,
             "-right-48 sm:-right-64": !isOpen,

--- a/src/components/navigation/hamburger/HamburgerModal.tsx
+++ b/src/components/navigation/hamburger/HamburgerModal.tsx
@@ -29,14 +29,14 @@ export default function HamburgerModal(): JSX.Element {
           }
         )}
       >
-        <ul className="flex flex-col space-y-1 sm:space-y-2">
+        <ul>
           {navLinks.map((link: NavLinkType) => (
-            <li
-              key={link.href}
-              onClick={handleCloseHamburger}
-              className="hover:bg-slate-700 px-3 sm:px-5 transition-colors duration-200"
-            >
-              <NavLink href={link.href} textClassName="text-lg sm:text-xl">
+            <li key={link.href} className="hover:bg-slate-700 transition-colors duration-200">
+              <NavLink
+                href={link.href}
+                className="text-lg sm:text-xl px-3 py-1 sm:px-5 sm:py-2 w-full block"
+                onClick={handleCloseHamburger}
+              >
                 {link.label}
               </NavLink>
             </li>

--- a/src/components/navigation/hamburger/HamburgerModal.tsx
+++ b/src/components/navigation/hamburger/HamburgerModal.tsx
@@ -22,7 +22,7 @@ export default function HamburgerModal(): JSX.Element {
     <>
       <nav
         className={cn(
-          "md:hidden bg-slate-800 absolute top-0 bottom-0 w-48 sm:w-64 h-full right-0 transition-all ease-in-out",
+          "md:hidden bg-slate-800 fixed top-[64px] bottom-0 w-48 sm:w-64 h-full right-0 transition-all ease-in-out",
           {
             "right-0": isOpen,
             "-right-48 sm:-right-64": !isOpen,

--- a/src/components/navigation/link/NavLink.tsx
+++ b/src/components/navigation/link/NavLink.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import { Text } from "@/components/ui";
 import { cn } from "@/utils/tailwind";
-import Link from "next/link";
+import Link, { LinkProps } from "next/link";
 import { usePathname } from "next/navigation";
 import { JSX } from "react";
 
-interface NavLinkProps {
+interface NavLinkProps extends LinkProps {
   href: string;
   children: React.ReactNode;
-  textClassName?: string;
+  className?: string;
 }
 
 /**
@@ -21,18 +20,21 @@ interface NavLinkProps {
 export default function NavLink({
   href,
   children,
-  textClassName,
+  className,
+  ...props
 }: Readonly<NavLinkProps>): JSX.Element {
   const pathname = usePathname();
   return (
     <Link
       href={href}
       className={cn(
-        "hover:opacity-60 transition-opacity duration-200",
+        "hover:opacity-70 transition-opacity duration-200",
+        className,
         pathname === href && "text-blue-400"
       )}
+      {...props}
     >
-      <Text className={textClassName}>{children}</Text>
+      {children}
     </Link>
   );
 }

--- a/src/components/navigation/link/NavLink.tsx
+++ b/src/components/navigation/link/NavLink.tsx
@@ -5,7 +5,7 @@ import Link, { LinkProps } from "next/link";
 import { usePathname } from "next/navigation";
 import { JSX } from "react";
 
-interface NavLinkProps extends LinkProps {
+interface NavLinkProps extends Omit<LinkProps, 'href'> {
   href: string;
   children: React.ReactNode;
   className?: string;

--- a/src/components/navigation/link/NavLinks.tsx
+++ b/src/components/navigation/link/NavLinks.tsx
@@ -13,7 +13,9 @@ export default function NavLinks() {
       <ul className="flex space-x-4">
         {navLinks.map((link: NavLinkType) => (
           <li key={link.href}>
-            <NavLink href={link.href}>{link.label}</NavLink>
+            <NavLink href={link.href} className="md:text-xl lg:text-2xl">
+              {link.label}
+            </NavLink>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## 内容
- HeaderのHeightを全体的に高くした
- HeaderLogoやNavLinks、HamburgerMenuのiconなどの大きさを大きくした
- HamburgerModalのNavLinkをblockにしてLinkにUIをつけた
- Headerのcontainerを削除した
- HamburgerModalをabsoluteからfixedに変更。それに伴うlayout.tsxからrelativeを削除した