### PR TITLE
refactor: navLinksのskillsのlableがskillsになっていたのでSkillsに修正した

### DIFF
--- a/src/config/link/navLinks.ts
+++ b/src/config/link/navLinks.ts
@@ -21,7 +21,7 @@ export const navLinks: NavLinkType[] = [
   },
   {
     href: "/skills",
-    label: "skills",
+    label: "Skills",
   },
   {
     href: "/contact",


### PR DESCRIPTION
## 内容
- navLinksのskillsのlabelがskillsになっていたのでSkillsに修正した