### PR TITLE
fix: headerを画面上部に固定する。また、それに伴う修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-900 text-white w-full`}
       >
         <Header />
-        <main className="w-full overflow-x-hidden">
+        <main className="w-full relative overflow-x-hidden mt-16 md:mt-18 lg:mt-20">
           {children}
           <HamburgerModal />
         </main>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -10,7 +10,7 @@ import { NavLinks } from "@/components/navigation/link";
  */
 export default function Header(): JSX.Element {
   return (
-    <header className="w-full h-16 md:h-18 lg:h-20 bg-gray-950 border-b border-gray-800 flex items-center">
+    <header className="fixed top-0 left-0 w-screen h-16 md:h-18 lg:h-20 bg-gray-950 border-b border-gray-800 flex items-center z-10">
       <div className="w-full flex items-center justify-between px-4">
         <HeaderLogo />
         <NavLinks />

--- a/src/components/navigation/hamburger/HamburgerModal.tsx
+++ b/src/components/navigation/hamburger/HamburgerModal.tsx
@@ -22,7 +22,7 @@ export default function HamburgerModal(): JSX.Element {
     <>
       <nav
         className={cn(
-          "md:hidden bg-slate-800 fixed top-16 bottom-0 w-48 sm:w-64 h-full right-0 transition-all ease-in-out",
+          "md:hidden bg-slate-800 fixed top-16 bottom-0 w-48 sm:w-64 h-full right-0 transition-all ease-in-out z-10",
           {
             "right-0": isOpen,
             "-right-48 sm:-right-64": !isOpen,


### PR DESCRIPTION
## 内容
- Headerを画面上部に固定
- HamburgerModalにz-indexを追加
- Headerを画面上部に固定したことによるlayout.tsxの修正